### PR TITLE
Fix pnpm setup in Cypress workflow

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -13,6 +13,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.11.0
       - name: Cypress run
         # Uses the official Cypress GitHub action https://github.com/cypress-io/github-action
         uses: cypress-io/github-action@v6


### PR DESCRIPTION
Add pnpm setup to Cypress workflow file.

* Add a step to set up `pnpm` using `pnpm/action-setup@v4` with version `10.11.0` before the `Cypress run` step in `.github/workflows/cypress.yml`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/thejokers69/GitHub-Profile-Viewer/pull/2?shareId=98b29195-063c-4a5d-9f77-f991e9c1ee32).

## Summary by Sourcery

CI:
- Add pnpm/action-setup@v4 step with version 10.11.0 to the Cypress workflow