### PR TITLE
Create dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,42 @@
+version: 2
+updates:
+  # Check for npm/pnpm package updates (for package.json)
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "UTC"
+    open-pull-requests-limit: 5
+    target-branch: "main"
+    labels:
+      - "dependencies"
+      - "pnpm"
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    ignore:
+      - dependency-name: "node"
+        versions: [">=23.x"] # Avoid breaking changes from Node.js 23+
+      - dependency-name: "npm"
+        versions: [">=12.x"] # Avoid breaking changes from npm 12+
+    reviewers:
+      - "your-github-username" # Replace with your GitHub username
+
+  # Check for GitHub Actions updates (for test.yml)
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "UTC"
+    open-pull-requests-limit: 3
+    target-branch: "main"
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"


### PR DESCRIPTION
This pull request introduces a new `.github/dependabot.yml` configuration file to automate dependency updates for both npm/pnpm packages and GitHub Actions. The configuration schedules weekly checks, applies labels, and sets limits on open pull requests.

### Dependabot configuration:

* Added a `version: 2` configuration file to enable Dependabot for the repository. Includes two update rules:
  - **npm/pnpm packages**: Configured to check for updates in `package.json` weekly on Mondays at 09:00 UTC, with a limit of 5 open pull requests and specific labels (`dependencies`, `pnpm`). Excludes breaking changes for Node.js 23+ and npm 12+.
  - **GitHub Actions**: Configured to check for updates in workflows weekly on Mondays at 09:00 UTC, with a limit of 3 open pull requests and specific labels (`dependencies`, `github-actions`).

## Summary by Sourcery

Introduce a Dependabot configuration file to automate weekly dependency updates for both npm/pnpm packages and GitHub Actions.

New Features:
- Add .github/dependabot.yml with version 2 configuration for Dependabot

Enhancements:
- Schedule weekly dependency checks on Mondays at 09:00 UTC for npm/pnpm and GitHub Actions
- Limit open pull requests (5 for packages, 3 for actions) and apply relevant labels
- Exclude updates for Node.js >=23 and npm >=12 to prevent breaking changes
- Standardize commit-message prefixes and assign a reviewer for dependency pull requests